### PR TITLE
addMode in macOS

### DIFF
--- a/dist/selectable.js
+++ b/dist/selectable.js
@@ -347,7 +347,7 @@ var selectable = function () {
             if (typeof this.selectingSetter === 'function') {
                 this.selectingSetter(this.selecting);
             }
-            this.addMode = e.ctrlKey;
+            this.addMode = e.ctrlKey || e.metaKey;
             if (!this.addMode) {
                 this.selected = this.selecting;
                 if (typeof this.selectedSetter === 'function') {

--- a/selectable.js
+++ b/selectable.js
@@ -212,7 +212,7 @@ export default class selectable {
         if (typeof this.selectingSetter === 'function') {
             this.selectingSetter(this.selecting);
         }
-        this.addMode = e.ctrlKey;
+        this.addMode = e.ctrlKey || e.metaKey;
         if (!this.addMode) {
             this.selected = this.selecting;
             if (typeof this.selectedSetter === 'function') {


### PR DESCRIPTION
- In macOS, ctrl key would cause right click
- people used to using cmd key to multi select

> e.metaKey means Cmd key in macOS and Win key in windows.