### PR TITLE
Allow overriding add-to option programmatically

### DIFF
--- a/dist/selectable.js
+++ b/dist/selectable.js
@@ -348,8 +348,6 @@ var selectable = function () {
                 this.selectingSetter(this.selecting);
             }
             this.addMode = this.overrideAddMode || e.ctrlKey || e.metaKey;
-            console.log("override add mode: ", this.overrideAddMode);
-            console.log("add mode: ", this.addMode);
             if (!this.addMode) {
                 this.selected = this.selecting;
                 if (typeof this.selectedSetter === 'function') {

--- a/dist/selectable.js
+++ b/dist/selectable.js
@@ -347,7 +347,9 @@ var selectable = function () {
             if (typeof this.selectingSetter === 'function') {
                 this.selectingSetter(this.selecting);
             }
-            this.addMode = this.addMode || e.ctrlKey || e.metaKey;
+            this.addMode = this.overrideAddMode || e.ctrlKey || e.metaKey;
+            console.log("override add mode: ", this.overrideAddMode);
+            console.log("add mode: ", this.addMode);
             if (!this.addMode) {
                 this.selected = this.selecting;
                 if (typeof this.selectedSetter === 'function') {
@@ -675,12 +677,10 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 var objectAssign = Object.assign || _selectable.objectAssignSimple;
 
 function initSelectable(el, params, arg) {
-    console.log(params);
     el.selectable = new _selectable2.default(objectAssign({
         boundingBox: !!params.constraint ? document.querySelector(params.constraint) : el,
         selectBoxSelector: params.box || '.selection',
-        boundingBoxSelector: params.constraint,
-        addMode: params.addMode
+        boundingBoxSelector: params.constraint
     }, arg));
     el.selectable.setSelectables(Array.prototype.slice.call(el.querySelectorAll(params.items || '.selectable')));
 }

--- a/dist/selectable.js
+++ b/dist/selectable.js
@@ -347,7 +347,7 @@ var selectable = function () {
             if (typeof this.selectingSetter === 'function') {
                 this.selectingSetter(this.selecting);
             }
-            this.addMode = e.ctrlKey || e.metaKey;
+            this.addMode = this.addMode || e.ctrlKey || e.metaKey;
             if (!this.addMode) {
                 this.selected = this.selecting;
                 if (typeof this.selectedSetter === 'function') {
@@ -675,10 +675,12 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 var objectAssign = Object.assign || _selectable.objectAssignSimple;
 
 function initSelectable(el, params, arg) {
+    console.log(params);
     el.selectable = new _selectable2.default(objectAssign({
         boundingBox: !!params.constraint ? document.querySelector(params.constraint) : el,
         selectBoxSelector: params.box || '.selection',
-        boundingBoxSelector: params.constraint
+        boundingBoxSelector: params.constraint,
+        addMode: params.addMode
     }, arg));
     el.selectable.setSelectables(Array.prototype.slice.call(el.querySelectorAll(params.items || '.selectable')));
 }

--- a/examples2/example4.html
+++ b/examples2/example4.html
@@ -59,6 +59,7 @@
         <button @click="selectAll">Select all</button>
         <button @click="invertSelection">Invert selection</button>
         <button @click="loadData">Reload data</button>
+        <input type="checkbox" v-model="addMode"> Toggle Add Mode
     </div>
 
     <div>
@@ -96,7 +97,8 @@
             selected: [],
             selecting: [],
             showHidden: false,
-            search: ''
+            search: '',
+            addMode: false
         },
 
         mounted() {
@@ -167,6 +169,9 @@
                     this.$nextTick(() => vueSelectable.setSelectableItems(this.$refs.vsel));
                 },
                 deep: true
+            },
+            addMode(val) {
+              vueSelectable.setOptions(this.$refs.vsel, { addMode: val });
             }
         },
 

--- a/examples2/example4.html
+++ b/examples2/example4.html
@@ -171,7 +171,7 @@
                 deep: true
             },
             addMode(val) {
-              vueSelectable.setOptions(this.$refs.vsel, { addMode: val });
+              vueSelectable.setOptions(this.$refs.vsel, { overrideAddMode: val });
             }
         },
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-selectable",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Directive to make objects selectable in vue.js application",
   "main": "dist/selectable.js",
   "repository": {

--- a/selectable.js
+++ b/selectable.js
@@ -212,7 +212,9 @@ export default class selectable {
         if (typeof this.selectingSetter === 'function') {
             this.selectingSetter(this.selecting);
         }
-        this.addMode = this.addMode || e.ctrlKey || e.metaKey;
+        this.addMode = this.overrideAddMode || e.ctrlKey || e.metaKey;
+        console.log("override add mode: ", this.overrideAddMode);
+        console.log("add mode: ", this.addMode);
         if (!this.addMode) {
             this.selected = this.selecting;
             if (typeof this.selectedSetter === 'function') {

--- a/selectable.js
+++ b/selectable.js
@@ -213,8 +213,6 @@ export default class selectable {
             this.selectingSetter(this.selecting);
         }
         this.addMode = this.overrideAddMode || e.ctrlKey || e.metaKey;
-        console.log("override add mode: ", this.overrideAddMode);
-        console.log("add mode: ", this.addMode);
         if (!this.addMode) {
             this.selected = this.selecting;
             if (typeof this.selectedSetter === 'function') {

--- a/selectable.js
+++ b/selectable.js
@@ -212,7 +212,7 @@ export default class selectable {
         if (typeof this.selectingSetter === 'function') {
             this.selectingSetter(this.selecting);
         }
-        this.addMode = e.ctrlKey || e.metaKey;
+        this.addMode = this.addMode || e.ctrlKey || e.metaKey;
         if (!this.addMode) {
             this.selected = this.selecting;
             if (typeof this.selectedSetter === 'function') {

--- a/v-selectable.js
+++ b/v-selectable.js
@@ -3,12 +3,10 @@ import selectable, { objectAssignSimple } from './selectable';
 const objectAssign = Object.assign || objectAssignSimple;
 
 function initSelectable(el, params, arg) {
-    console.log(params);
     el.selectable = new selectable(objectAssign({
         boundingBox: !!params.constraint ? document.querySelector(params.constraint) : el,
         selectBoxSelector: params.box || '.selection',
-        boundingBoxSelector: params.constraint,
-        addMode: params.addMode
+        boundingBoxSelector: params.constraint
     }, arg));
     el.selectable.setSelectables(Array.prototype.slice.call(el.querySelectorAll(params.items || '.selectable')));
 }

--- a/v-selectable.js
+++ b/v-selectable.js
@@ -3,10 +3,12 @@ import selectable, { objectAssignSimple } from './selectable';
 const objectAssign = Object.assign || objectAssignSimple;
 
 function initSelectable(el, params, arg) {
+    console.log(params);
     el.selectable = new selectable(objectAssign({
         boundingBox: !!params.constraint ? document.querySelector(params.constraint) : el,
         selectBoxSelector: params.box || '.selection',
-        boundingBoxSelector: params.constraint
+        boundingBoxSelector: params.constraint,
+        addMode: params.addMode
     }, arg));
     el.selectable.setSelectables(Array.prototype.slice.call(el.querySelectorAll(params.items || '.selectable')));
 }


### PR DESCRIPTION
This addresses my feature request (https://github.com/JSmith01/vue-selectable/issues/9) to let the user override 'addTo' programmatically, as opposed to just via the cmd key.